### PR TITLE
make the custom view transparent

### DIFF
--- a/Sources/CalendarView/Decoration+SwiftUI.swift
+++ b/Sources/CalendarView/Decoration+SwiftUI.swift
@@ -32,7 +32,9 @@ public extension UICalendarView.Decoration {
 	
 	static func customView(_ customView: @escaping () -> some View) -> Self {
 		.customView {
-			UIHostingController(rootView: customView()).view
+			let view = UIHostingController(rootView: customView()).view!
+			view.backgroundColor = .clear
+			return view
 		}
 	}
 }


### PR DESCRIPTION
The custom view had a white background color which doens't look great when the calendar has a different background.